### PR TITLE
Fix problematic README markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
-🚨Alert🚨Apache Vulnerability 
+# 🚨Alert🚨Apache Vulnerability<br>🚨Alert🚨Security Advisory: CVE-2024-40725 and CVE-2024-40898🚨Alert🚨
 
-🚨Alert🚨Security Advisory: CVE-2024-40725 and CVE-2024-40898🚨Alert🚨
+## CVE-2024-40725
 
-CVE-2024-40725
-Description:
+### Description
+
 CVE-2024-40725 is a high-severity vulnerability found in Apache HTTP Server versions 2.4.0 to 2.4.61. This vulnerability affects the mod_proxy module. When the ProxyPass directive is enabled and URL rewrite rules are configured, an attacker can exploit this vulnerability to perform HTTP Request Smuggling attacks. This type of attack exploits discrepancies in the parsing of HTTP requests between proxy and backend servers, potentially leading to unauthorized actions such as information disclosure or unauthorized data access.
-Affected Versions:
+
+### Affected Versions
+
 - Apache HTTP Server 2.4.0 to 2.4.61
-Attack Method:
+
+### Attack Method
 
 1. Identify Target Configuration:
    - The attacker needs to identify if the target system uses an affected version of Apache HTTP Server and has the mod_proxy module enabled.
@@ -22,19 +25,24 @@ Attack Method:
 
 4. Exploit Smuggled Request:
    - Use the smuggled request to perform further attacks, such as session hijacking, cross-site scripting (XSS), or command injection.
-Mitigation:
+
+### Mitigation
+
 - Upgrade to Apache HTTP Server 2.4.62 or later to fix this vulnerability.
 - Ensure proper configuration of proxy settings to avoid insecure URL rewrite rules.
 - Review and strengthen proxy configurations to ensure consistent parsing between proxy and backend servers.
-CVE-2024-40898
 
-Description:
+## CVE-2024-40898
+
+### Description
+
 CVE-2024-40898 is another high-severity vulnerability affecting Apache HTTP Server versions 2.4.0 to 2.4.61. This vulnerability involves the mod_ssl module. When the SSLVerifyClient directive is configured in a specific manner, there is a risk of authentication bypass. An attacker can exploit this vulnerability to bypass client authentication, leading to unauthorized access to the system or sensitive information.
 
-Affected Versions:
+### Affected Versions
+
 - Apache HTTP Server 2.4.0 to 2.4.61
 
-Attack Method:
+### Attack Method
 
 1. Analyze Target SSL Configuration:
    - The attacker needs to identify if the target system uses an affected version of Apache HTTP Server and has the SSLVerifyClient directive configured.
@@ -50,7 +58,8 @@ Attack Method:
 4. Exploit Bypassed Authentication:
    - The attacker uses the bypassed authentication to perform further attacks, such as data theft, configuration changes, or system intrusion.
 
-Mitigation:
+### Mitigation
+
 - Upgrade to Apache HTTP Server 2.4.62 or later to fix this vulnerability.
 - Review and update SSL configurations to ensure the proper use of the SSLVerifyClient directive, avoiding authentication bypass risks.
 - Strengthen SSL configurations to ensure the effectiveness and security of client authentication mechanisms.


### PR DESCRIPTION
This patch fixes problematic Markdown markup in the README document, which leads to less readability and missing linebreaks.